### PR TITLE
Dont `.fernignore` any polling utilities

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,6 +1,3 @@
 # Specify files that shouldn't be modified by Fern
 
 README.md
-sample-app/src/main/java/sample/App.java
-src/main/java/com/seam/api/SeamApiClient.java
-src/main/java/com/seam/api/AccessCodesClient.java


### PR DESCRIPTION
When the fern team originally generated this SDK we added some custom code to preserve the `pollUntilReady` functionality. This is something that the Seam team doesn't want to support in the existing SDKs, so this PR removes the extra methods.