### PR TITLE
:herb: .fernignore only ignores README

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,6 +1,3 @@
 # Specify files that shouldn't be modified by Fern
 
 README.md
-sample-app/src/main/java/sample/App.java
-src/main/java/com/seam/api/SeamApiClient.java
-src/main/java/com/seam/api/AccessCodesClient.java


### PR DESCRIPTION
We no longer need overrides for access code polling.