### PR TITLE
🌿 regenerate sdk and return resources directly

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,3 +1,18 @@
 # Specify files that shouldn't be modified by Fern
 
 README.md
+
+# return resources directly
+src/main/java/com/seam/api/types/DevicesListDeviceProvidersResponse.java
+src/main/java/com/seam/api/types/DeviceListProvider.java
+src/main/java/com/seam/api/resources/workspaces/WorkspacesClient.java
+src/main/java/com/seam/api/resources/thermostats/ThermostatsClient.java
+src/main/java/com/seam/api/resources/noisesensors/noisethresholds/NoiseThresholdsClient.java
+src/main/java/com/seam/api/resources/locks/LocksClient.java
+src/main/java/com/seam/api/resources/events/EventsClient.java
+src/main/java/com/seam/api/resources/devices/DevicesClient.java
+src/main/java/com/seam/api/resources/connectwebviews/ConnectWebviewsClient.java
+src/main/java/com/seam/api/resources/connectedaccounts/ConnectedAccountsClient.java
+src/main/java/com/seam/api/resources/clientsessions/ClientSessionsClient.java
+src/main/java/com/seam/api/resources/actionattempts/ActionAttemptsClient.java
+src/main/java/com/seam/api/resources/accesscodes/AccessCodesClient.java

--- a/src/main/java/com/seam/api/resources/accesscodes/AccessCodesClient.java
+++ b/src/main/java/com/seam/api/resources/accesscodes/AccessCodesClient.java
@@ -17,6 +17,7 @@ import com.seam.api.resources.accesscodes.requests.AccessCodesPullBackupAccessCo
 import com.seam.api.resources.accesscodes.requests.AccessCodesUpdateRequest;
 import com.seam.api.resources.accesscodes.simulate.SimulateClient;
 import com.seam.api.resources.accesscodes.unmanaged.UnmanagedClient;
+import com.seam.api.types.AccessCode;
 import com.seam.api.types.AccessCodesCreateMultipleResponse;
 import com.seam.api.types.AccessCodesCreateResponse;
 import com.seam.api.types.AccessCodesDeleteResponse;
@@ -24,7 +25,9 @@ import com.seam.api.types.AccessCodesGetResponse;
 import com.seam.api.types.AccessCodesListResponse;
 import com.seam.api.types.AccessCodesPullBackupAccessCodeResponse;
 import com.seam.api.types.AccessCodesUpdateResponse;
+import com.seam.api.types.ActionAttempt;
 import java.io.IOException;
+import java.util.List;
 import java.util.function.Supplier;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
@@ -46,11 +49,11 @@ public class AccessCodesClient {
         this.unmanagedClient = Suppliers.memoize(() -> new UnmanagedClient(clientOptions));
     }
 
-    public AccessCodesCreateResponse create(AccessCodesCreateRequest request) {
+    public AccessCode create(AccessCodesCreateRequest request) {
         return create(request, null);
     }
 
-    public AccessCodesCreateResponse create(AccessCodesCreateRequest request, RequestOptions requestOptions) {
+    public AccessCode create(AccessCodesCreateRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("access_codes/create")
@@ -72,7 +75,9 @@ public class AccessCodesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), AccessCodesCreateResponse.class);
+                AccessCodesCreateResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), AccessCodesCreateResponse.class);
+                return parsedResponse.getAccessCode();
             }
             throw new ApiError(
                     response.code(),
@@ -82,11 +87,11 @@ public class AccessCodesClient {
         }
     }
 
-    public AccessCodesCreateMultipleResponse createMultiple(AccessCodesCreateMultipleRequest request) {
+    public List<AccessCode> createMultiple(AccessCodesCreateMultipleRequest request) {
         return createMultiple(request, null);
     }
 
-    public AccessCodesCreateMultipleResponse createMultiple(
+    public List<AccessCode> createMultiple(
             AccessCodesCreateMultipleRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
@@ -109,8 +114,9 @@ public class AccessCodesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(
+                AccessCodesCreateMultipleResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
                         response.body().string(), AccessCodesCreateMultipleResponse.class);
+                return parsedResponse.getAccessCodes();
             }
             throw new ApiError(
                     response.code(),
@@ -120,11 +126,11 @@ public class AccessCodesClient {
         }
     }
 
-    public AccessCodesDeleteResponse delete(AccessCodesDeleteRequest request) {
+    public ActionAttempt delete(AccessCodesDeleteRequest request) {
         return delete(request, null);
     }
 
-    public AccessCodesDeleteResponse delete(AccessCodesDeleteRequest request, RequestOptions requestOptions) {
+    public ActionAttempt delete(AccessCodesDeleteRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("access_codes/delete")
@@ -146,7 +152,9 @@ public class AccessCodesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), AccessCodesDeleteResponse.class);
+                AccessCodesDeleteResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), AccessCodesDeleteResponse.class);
+                return parsedResponse.getActionAttempt();
             }
             throw new ApiError(
                     response.code(),
@@ -156,11 +164,11 @@ public class AccessCodesClient {
         }
     }
 
-    public AccessCodesGetResponse get(AccessCodesGetRequest request) {
+    public AccessCode get(AccessCodesGetRequest request) {
         return get(request, null);
     }
 
-    public AccessCodesGetResponse get(AccessCodesGetRequest request, RequestOptions requestOptions) {
+    public AccessCode get(AccessCodesGetRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("access_codes/get")
@@ -182,7 +190,9 @@ public class AccessCodesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), AccessCodesGetResponse.class);
+                AccessCodesGetResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
+                        response.body().string(), AccessCodesGetResponse.class);
+                return parsedResponse.getAccessCode();
             }
             throw new ApiError(
                     response.code(),
@@ -192,15 +202,15 @@ public class AccessCodesClient {
         }
     }
 
-    public AccessCodesGetResponse get() {
+    public AccessCode get() {
         return get(AccessCodesGetRequest.builder().build());
     }
 
-    public AccessCodesListResponse list(AccessCodesListRequest request) {
+    public List<AccessCode> list(AccessCodesListRequest request) {
         return list(request, null);
     }
 
-    public AccessCodesListResponse list(AccessCodesListRequest request, RequestOptions requestOptions) {
+    public List<AccessCode> list(AccessCodesListRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("access_codes/list")
@@ -222,7 +232,9 @@ public class AccessCodesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), AccessCodesListResponse.class);
+                AccessCodesListResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
+                        response.body().string(), AccessCodesListResponse.class);
+                parsedResponse.getAccessCodes();
             }
             throw new ApiError(
                     response.code(),
@@ -232,12 +244,12 @@ public class AccessCodesClient {
         }
     }
 
-    public AccessCodesPullBackupAccessCodeResponse pullBackupAccessCode(
+    public AccessCode pullBackupAccessCode(
             AccessCodesPullBackupAccessCodeRequest request) {
         return pullBackupAccessCode(request, null);
     }
 
-    public AccessCodesPullBackupAccessCodeResponse pullBackupAccessCode(
+    public AccessCode pullBackupAccessCode(
             AccessCodesPullBackupAccessCodeRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
@@ -260,8 +272,9 @@ public class AccessCodesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(
+                AccessCodesPullBackupAccessCodeResponse parsedResposne = ObjectMappers.JSON_MAPPER.readValue(
                         response.body().string(), AccessCodesPullBackupAccessCodeResponse.class);
+                return parsedResposne.getBackupAccessCode();
             }
             throw new ApiError(
                     response.code(),
@@ -271,11 +284,11 @@ public class AccessCodesClient {
         }
     }
 
-    public AccessCodesUpdateResponse update(AccessCodesUpdateRequest request) {
+    public ActionAttempt update(AccessCodesUpdateRequest request) {
         return update(request, null);
     }
 
-    public AccessCodesUpdateResponse update(AccessCodesUpdateRequest request, RequestOptions requestOptions) {
+    public ActionAttempt update(AccessCodesUpdateRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("access_codes/update")
@@ -297,7 +310,9 @@ public class AccessCodesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), AccessCodesUpdateResponse.class);
+                AccessCodesUpdateResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
+                        response.body().string(), AccessCodesUpdateResponse.class);
+                return parsedResponse.getActionAttempt();
             }
             throw new ApiError(
                     response.code(),

--- a/src/main/java/com/seam/api/resources/actionattempts/ActionAttemptsClient.java
+++ b/src/main/java/com/seam/api/resources/actionattempts/ActionAttemptsClient.java
@@ -9,9 +9,11 @@ import com.seam.api.core.ObjectMappers;
 import com.seam.api.core.RequestOptions;
 import com.seam.api.resources.actionattempts.requests.ActionAttemptsGetRequest;
 import com.seam.api.resources.actionattempts.requests.ActionAttemptsListRequest;
+import com.seam.api.types.ActionAttempt;
 import com.seam.api.types.ActionAttemptsGetResponse;
 import com.seam.api.types.ActionAttemptsListResponse;
 import java.io.IOException;
+import java.util.List;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -26,11 +28,11 @@ public class ActionAttemptsClient {
         this.clientOptions = clientOptions;
     }
 
-    public ActionAttemptsGetResponse get(ActionAttemptsGetRequest request) {
+    public ActionAttempt get(ActionAttemptsGetRequest request) {
         return get(request, null);
     }
 
-    public ActionAttemptsGetResponse get(ActionAttemptsGetRequest request, RequestOptions requestOptions) {
+    public ActionAttempt get(ActionAttemptsGetRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("action_attempts/get")
@@ -52,7 +54,9 @@ public class ActionAttemptsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ActionAttemptsGetResponse.class);
+                ActionAttemptsGetResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
+                        response.body().string(), ActionAttemptsGetResponse.class);
+                return parsedResponse.getActionAttempt();
             }
             throw new ApiError(
                     response.code(),
@@ -62,11 +66,11 @@ public class ActionAttemptsClient {
         }
     }
 
-    public ActionAttemptsListResponse list(ActionAttemptsListRequest request) {
+    public List<ActionAttempt> list(ActionAttemptsListRequest request) {
         return list(request, null);
     }
 
-    public ActionAttemptsListResponse list(ActionAttemptsListRequest request, RequestOptions requestOptions) {
+    public List<ActionAttempt> list(ActionAttemptsListRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("action_attempts/list")
@@ -88,7 +92,9 @@ public class ActionAttemptsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ActionAttemptsListResponse.class);
+                ActionAttemptsListResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ActionAttemptsListResponse.class);
+                return parsedResponse.getActionAttempts();
             }
             throw new ApiError(
                     response.code(),

--- a/src/main/java/com/seam/api/resources/clientsessions/ClientSessionsClient.java
+++ b/src/main/java/com/seam/api/resources/clientsessions/ClientSessionsClient.java
@@ -11,11 +11,13 @@ import com.seam.api.resources.clientsessions.requests.ClientSessionsCreateReques
 import com.seam.api.resources.clientsessions.requests.ClientSessionsDeleteRequest;
 import com.seam.api.resources.clientsessions.requests.ClientSessionsGetRequest;
 import com.seam.api.resources.clientsessions.requests.ClientSessionsListRequest;
+import com.seam.api.types.ClientSession;
 import com.seam.api.types.ClientSessionsCreateResponse;
 import com.seam.api.types.ClientSessionsDeleteResponse;
 import com.seam.api.types.ClientSessionsGetResponse;
 import com.seam.api.types.ClientSessionsListResponse;
 import java.io.IOException;
+import java.util.List;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -30,11 +32,11 @@ public class ClientSessionsClient {
         this.clientOptions = clientOptions;
     }
 
-    public ClientSessionsCreateResponse create(ClientSessionsCreateRequest request) {
+    public ClientSession create(ClientSessionsCreateRequest request) {
         return create(request, null);
     }
 
-    public ClientSessionsCreateResponse create(ClientSessionsCreateRequest request, RequestOptions requestOptions) {
+    public ClientSession create(ClientSessionsCreateRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("client_sessions/create")
@@ -56,8 +58,9 @@ public class ClientSessionsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(
+                ClientSessionsCreateResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
                         response.body().string(), ClientSessionsCreateResponse.class);
+                return parsedResponse.getClientSession();
             }
             throw new ApiError(
                     response.code(),
@@ -67,15 +70,15 @@ public class ClientSessionsClient {
         }
     }
 
-    public ClientSessionsCreateResponse create() {
+    public ClientSession create() {
         return create(ClientSessionsCreateRequest.builder().build());
     }
 
-    public ClientSessionsDeleteResponse delete(ClientSessionsDeleteRequest request) {
-        return delete(request, null);
+    public void delete(ClientSessionsDeleteRequest request) {
+        delete(request, null);
     }
 
-    public ClientSessionsDeleteResponse delete(ClientSessionsDeleteRequest request, RequestOptions requestOptions) {
+    public void delete(ClientSessionsDeleteRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("client_sessions/delete")
@@ -97,8 +100,9 @@ public class ClientSessionsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(
+                ObjectMappers.JSON_MAPPER.readValue(
                         response.body().string(), ClientSessionsDeleteResponse.class);
+                return;
             }
             throw new ApiError(
                     response.code(),
@@ -108,11 +112,11 @@ public class ClientSessionsClient {
         }
     }
 
-    public ClientSessionsGetResponse get(ClientSessionsGetRequest request) {
+    public ClientSession get(ClientSessionsGetRequest request) {
         return get(request, null);
     }
 
-    public ClientSessionsGetResponse get(ClientSessionsGetRequest request, RequestOptions requestOptions) {
+    public ClientSession get(ClientSessionsGetRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("client_sessions/get")
@@ -134,7 +138,9 @@ public class ClientSessionsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ClientSessionsGetResponse.class);
+                ClientSessionsGetResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ClientSessionsGetResponse.class);
+                return parsedResponse.getClientSession();
             }
             throw new ApiError(
                     response.code(),
@@ -144,15 +150,15 @@ public class ClientSessionsClient {
         }
     }
 
-    public ClientSessionsGetResponse get() {
+    public ClientSession get() {
         return get(ClientSessionsGetRequest.builder().build());
     }
 
-    public ClientSessionsListResponse list(ClientSessionsListRequest request) {
+    public List<ClientSession> list(ClientSessionsListRequest request) {
         return list(request, null);
     }
 
-    public ClientSessionsListResponse list(ClientSessionsListRequest request, RequestOptions requestOptions) {
+    public List<ClientSession> list(ClientSessionsListRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("client_sessions/list")
@@ -174,7 +180,9 @@ public class ClientSessionsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ClientSessionsListResponse.class);
+                ClientSessionsListResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ClientSessionsListResponse.class);
+                return parsedResponse.getClientSessions();
             }
             throw new ApiError(
                     response.code(),
@@ -184,7 +192,7 @@ public class ClientSessionsClient {
         }
     }
 
-    public ClientSessionsListResponse list() {
+    public List<ClientSession> list() {
         return list(ClientSessionsListRequest.builder().build());
     }
 }

--- a/src/main/java/com/seam/api/resources/connectedaccounts/ConnectedAccountsClient.java
+++ b/src/main/java/com/seam/api/resources/connectedaccounts/ConnectedAccountsClient.java
@@ -8,11 +8,13 @@ import com.seam.api.core.ClientOptions;
 import com.seam.api.core.ObjectMappers;
 import com.seam.api.core.RequestOptions;
 import com.seam.api.resources.connectedaccounts.requests.ConnectedAccountsDeleteRequest;
+import com.seam.api.types.ConnectedAccount;
 import com.seam.api.types.ConnectedAccountsDeleteResponse;
 import com.seam.api.types.ConnectedAccountsGetRequest;
 import com.seam.api.types.ConnectedAccountsGetResponse;
 import com.seam.api.types.ConnectedAccountsListResponse;
 import java.io.IOException;
+import java.util.List;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -27,11 +29,11 @@ public class ConnectedAccountsClient {
         this.clientOptions = clientOptions;
     }
 
-    public ConnectedAccountsDeleteResponse delete(ConnectedAccountsDeleteRequest request) {
-        return delete(request, null);
+    public void delete(ConnectedAccountsDeleteRequest request) {
+        delete(request, null);
     }
 
-    public ConnectedAccountsDeleteResponse delete(
+    public void delete(
             ConnectedAccountsDeleteRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
@@ -54,8 +56,9 @@ public class ConnectedAccountsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(
+                ObjectMappers.JSON_MAPPER.readValue(
                         response.body().string(), ConnectedAccountsDeleteResponse.class);
+                return;
             }
             throw new ApiError(
                     response.code(),
@@ -65,11 +68,11 @@ public class ConnectedAccountsClient {
         }
     }
 
-    public ConnectedAccountsGetResponse get(ConnectedAccountsGetRequest request) {
+    public ConnectedAccount get(ConnectedAccountsGetRequest request) {
         return get(request, null);
     }
 
-    public ConnectedAccountsGetResponse get(ConnectedAccountsGetRequest request, RequestOptions requestOptions) {
+    public ConnectedAccount get(ConnectedAccountsGetRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("connected_accounts/get")
@@ -91,8 +94,9 @@ public class ConnectedAccountsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(
+                ConnectedAccountsGetResponse parsedResponse =  ObjectMappers.JSON_MAPPER.readValue(
                         response.body().string(), ConnectedAccountsGetResponse.class);
+                return parsedResponse.getConnectedAccount();
             }
             throw new ApiError(
                     response.code(),
@@ -102,11 +106,11 @@ public class ConnectedAccountsClient {
         }
     }
 
-    public ConnectedAccountsListResponse list() {
+    public List<ConnectedAccount> list() {
         return list(null);
     }
 
-    public ConnectedAccountsListResponse list(RequestOptions requestOptions) {
+    public List<ConnectedAccount> list(RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("connected_accounts/list")
@@ -121,8 +125,9 @@ public class ConnectedAccountsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(
+                ConnectedAccountsListResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
                         response.body().string(), ConnectedAccountsListResponse.class);
+                return parsedResponse.getConnectedAccounts();
             }
             throw new ApiError(
                     response.code(),

--- a/src/main/java/com/seam/api/resources/connectwebviews/ConnectWebviewsClient.java
+++ b/src/main/java/com/seam/api/resources/connectwebviews/ConnectWebviewsClient.java
@@ -11,11 +11,13 @@ import com.seam.api.resources.connectwebviews.requests.ConnectWebviewsCreateRequ
 import com.seam.api.resources.connectwebviews.requests.ConnectWebviewsDeleteRequest;
 import com.seam.api.resources.connectwebviews.requests.ConnectWebviewsGetRequest;
 import com.seam.api.resources.connectwebviews.requests.ConnectWebviewsViewRequest;
+import com.seam.api.types.ConnectWebview;
 import com.seam.api.types.ConnectWebviewsCreateResponse;
 import com.seam.api.types.ConnectWebviewsDeleteResponse;
 import com.seam.api.types.ConnectWebviewsGetResponse;
 import com.seam.api.types.ConnectWebviewsListResponse;
 import java.io.IOException;
+import java.util.List;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -30,11 +32,11 @@ public class ConnectWebviewsClient {
         this.clientOptions = clientOptions;
     }
 
-    public ConnectWebviewsCreateResponse create(ConnectWebviewsCreateRequest request) {
+    public ConnectWebview create(ConnectWebviewsCreateRequest request) {
         return create(request, null);
     }
 
-    public ConnectWebviewsCreateResponse create(ConnectWebviewsCreateRequest request, RequestOptions requestOptions) {
+    public ConnectWebview create(ConnectWebviewsCreateRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("connect_webviews/create")
@@ -56,8 +58,9 @@ public class ConnectWebviewsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(
+                ConnectWebviewsCreateResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
                         response.body().string(), ConnectWebviewsCreateResponse.class);
+                return parsedResponse.getConnectWebview();
             }
             throw new ApiError(
                     response.code(),
@@ -67,15 +70,15 @@ public class ConnectWebviewsClient {
         }
     }
 
-    public ConnectWebviewsCreateResponse create() {
+    public ConnectWebview create() {
         return create(ConnectWebviewsCreateRequest.builder().build());
     }
 
-    public ConnectWebviewsDeleteResponse delete(ConnectWebviewsDeleteRequest request) {
-        return delete(request, null);
+    public void delete(ConnectWebviewsDeleteRequest request) {
+        delete(request, null);
     }
 
-    public ConnectWebviewsDeleteResponse delete(ConnectWebviewsDeleteRequest request, RequestOptions requestOptions) {
+    public void delete(ConnectWebviewsDeleteRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("connect_webviews/delete")
@@ -97,8 +100,9 @@ public class ConnectWebviewsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(
+                ObjectMappers.JSON_MAPPER.readValue(
                         response.body().string(), ConnectWebviewsDeleteResponse.class);
+                return;
             }
             throw new ApiError(
                     response.code(),
@@ -108,11 +112,11 @@ public class ConnectWebviewsClient {
         }
     }
 
-    public ConnectWebviewsGetResponse get(ConnectWebviewsGetRequest request) {
+    public ConnectWebview get(ConnectWebviewsGetRequest request) {
         return get(request, null);
     }
 
-    public ConnectWebviewsGetResponse get(ConnectWebviewsGetRequest request, RequestOptions requestOptions) {
+    public ConnectWebview get(ConnectWebviewsGetRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("connect_webviews/get")
@@ -134,7 +138,9 @@ public class ConnectWebviewsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ConnectWebviewsGetResponse.class);
+                ConnectWebviewsGetResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ConnectWebviewsGetResponse.class);
+                return parsedResponse.getConnectWebview();
             }
             throw new ApiError(
                     response.code(),
@@ -144,11 +150,11 @@ public class ConnectWebviewsClient {
         }
     }
 
-    public ConnectWebviewsListResponse list() {
+    public List<ConnectWebview> list() {
         return list(null);
     }
 
-    public ConnectWebviewsListResponse list(RequestOptions requestOptions) {
+    public List<ConnectWebview> list(RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("connect_webviews/list")
@@ -163,7 +169,9 @@ public class ConnectWebviewsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ConnectWebviewsListResponse.class);
+                ConnectWebviewsListResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ConnectWebviewsListResponse.class);
+                return parsedResponse.getConnectWebviews();
             }
             throw new ApiError(
                     response.code(),

--- a/src/main/java/com/seam/api/resources/devices/DevicesClient.java
+++ b/src/main/java/com/seam/api/resources/devices/DevicesClient.java
@@ -14,12 +14,15 @@ import com.seam.api.resources.devices.requests.DevicesListDeviceProvidersRequest
 import com.seam.api.resources.devices.requests.DevicesListRequest;
 import com.seam.api.resources.devices.requests.DevicesUpdateRequest;
 import com.seam.api.resources.devices.unmanaged.UnmanagedClient;
+import com.seam.api.types.Device;
+import com.seam.api.types.DeviceListProvider;
 import com.seam.api.types.DevicesDeleteResponse;
 import com.seam.api.types.DevicesGetResponse;
 import com.seam.api.types.DevicesListDeviceProvidersResponse;
 import com.seam.api.types.DevicesListResponse;
 import com.seam.api.types.DevicesUpdateResponse;
 import java.io.IOException;
+import java.util.List;
 import java.util.function.Supplier;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
@@ -38,11 +41,11 @@ public class DevicesClient {
         this.unmanagedClient = Suppliers.memoize(() -> new UnmanagedClient(clientOptions));
     }
 
-    public DevicesDeleteResponse delete(DevicesDeleteRequest request) {
-        return delete(request, null);
+    public void delete(DevicesDeleteRequest request) {
+        delete(request, null);
     }
 
-    public DevicesDeleteResponse delete(DevicesDeleteRequest request, RequestOptions requestOptions) {
+    public void delete(DevicesDeleteRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("devices/delete")
@@ -64,7 +67,8 @@ public class DevicesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), DevicesDeleteResponse.class);
+                ObjectMappers.JSON_MAPPER.readValue(response.body().string(), DevicesDeleteResponse.class);
+                return;
             }
             throw new ApiError(
                     response.code(),
@@ -74,11 +78,11 @@ public class DevicesClient {
         }
     }
 
-    public DevicesGetResponse get(DevicesGetRequest request) {
+    public Device get(DevicesGetRequest request) {
         return get(request, null);
     }
 
-    public DevicesGetResponse get(DevicesGetRequest request, RequestOptions requestOptions) {
+    public Device get(DevicesGetRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("devices/get")
@@ -100,7 +104,9 @@ public class DevicesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), DevicesGetResponse.class);
+                DevicesGetResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), DevicesGetResponse.class);
+                return parsedResponse.getDevice();
             }
             throw new ApiError(
                     response.code(),
@@ -110,15 +116,15 @@ public class DevicesClient {
         }
     }
 
-    public DevicesGetResponse get() {
+    public Device get() {
         return get(DevicesGetRequest.builder().build());
     }
 
-    public DevicesListResponse list(DevicesListRequest request) {
+    public List<Device> list(DevicesListRequest request) {
         return list(request, null);
     }
 
-    public DevicesListResponse list(DevicesListRequest request, RequestOptions requestOptions) {
+    public List<Device> list(DevicesListRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("devices/list")
@@ -140,7 +146,9 @@ public class DevicesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), DevicesListResponse.class);
+                DevicesListResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), DevicesListResponse.class);
+                return parsedResponse.getDevices();
             }
             throw new ApiError(
                     response.code(),
@@ -150,15 +158,15 @@ public class DevicesClient {
         }
     }
 
-    public DevicesListResponse list() {
+    public List<Device> list() {
         return list(DevicesListRequest.builder().build());
     }
 
-    public DevicesListDeviceProvidersResponse listDeviceProviders(DevicesListDeviceProvidersRequest request) {
+    public List<DeviceListProvider> listDeviceProviders(DevicesListDeviceProvidersRequest request) {
         return listDeviceProviders(request, null);
     }
 
-    public DevicesListDeviceProvidersResponse listDeviceProviders(
+    public List<DeviceListProvider> listDeviceProviders(
             DevicesListDeviceProvidersRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
@@ -181,8 +189,9 @@ public class DevicesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(
+                DevicesListDeviceProvidersResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
                         response.body().string(), DevicesListDeviceProvidersResponse.class);
+                return parsedResponse.getDeviceProviders();
             }
             throw new ApiError(
                     response.code(),
@@ -192,15 +201,15 @@ public class DevicesClient {
         }
     }
 
-    public DevicesListDeviceProvidersResponse listDeviceProviders() {
+    public List<DeviceListProvider> listDeviceProviders() {
         return listDeviceProviders(DevicesListDeviceProvidersRequest.builder().build());
     }
 
-    public DevicesUpdateResponse update(DevicesUpdateRequest request) {
-        return update(request, null);
+    public void update(DevicesUpdateRequest request) {
+        update(request, null);
     }
 
-    public DevicesUpdateResponse update(DevicesUpdateRequest request, RequestOptions requestOptions) {
+    public void update(DevicesUpdateRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("devices/update")
@@ -222,7 +231,8 @@ public class DevicesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), DevicesUpdateResponse.class);
+                ObjectMappers.JSON_MAPPER.readValue(response.body().string(), DevicesUpdateResponse.class);
+                return;
             }
             throw new ApiError(
                     response.code(),

--- a/src/main/java/com/seam/api/resources/events/EventsClient.java
+++ b/src/main/java/com/seam/api/resources/events/EventsClient.java
@@ -9,9 +9,13 @@ import com.seam.api.core.ObjectMappers;
 import com.seam.api.core.RequestOptions;
 import com.seam.api.resources.events.requests.EventsGetRequest;
 import com.seam.api.resources.events.requests.EventsListRequest;
+import com.seam.api.types.Event;
 import com.seam.api.types.EventsGetResponse;
 import com.seam.api.types.EventsListResponse;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -26,11 +30,11 @@ public class EventsClient {
         this.clientOptions = clientOptions;
     }
 
-    public EventsGetResponse get(EventsGetRequest request) {
+    public Optional<Event> get(EventsGetRequest request) {
         return get(request, null);
     }
 
-    public EventsGetResponse get(EventsGetRequest request, RequestOptions requestOptions) {
+    public Optional<Event> get(EventsGetRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("events/get")
@@ -52,7 +56,9 @@ public class EventsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), EventsGetResponse.class);
+                EventsGetResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), EventsGetResponse.class);
+                return parsedResponse.getEvent();
             }
             throw new ApiError(
                     response.code(),
@@ -62,15 +68,15 @@ public class EventsClient {
         }
     }
 
-    public EventsGetResponse get() {
+    public Optional<Event> get() {
         return get(EventsGetRequest.builder().build());
     }
 
-    public EventsListResponse list(EventsListRequest request) {
+    public List<Event> list(EventsListRequest request) {
         return list(request, null);
     }
 
-    public EventsListResponse list(EventsListRequest request, RequestOptions requestOptions) {
+    public List<Event> list(EventsListRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("events/list")
@@ -92,7 +98,9 @@ public class EventsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), EventsListResponse.class);
+                EventsListResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), EventsListResponse.class);
+                return parsedResponse.getEvents().orElse(Collections.emptyList());
             }
             throw new ApiError(
                     response.code(),
@@ -102,7 +110,7 @@ public class EventsClient {
         }
     }
 
-    public EventsListResponse list() {
+    public List<Event> list() {
         return list(EventsListRequest.builder().build());
     }
 }

--- a/src/main/java/com/seam/api/resources/locks/LocksClient.java
+++ b/src/main/java/com/seam/api/resources/locks/LocksClient.java
@@ -11,6 +11,7 @@ import com.seam.api.resources.locks.requests.LocksGetRequest;
 import com.seam.api.resources.locks.requests.LocksListRequest;
 import com.seam.api.resources.locks.requests.LocksLockDoorRequest;
 import com.seam.api.resources.locks.requests.LocksUnlockDoorRequest;
+import com.seam.api.types.ActionAttempt;
 import com.seam.api.types.LocksGetResponse;
 import com.seam.api.types.LocksListResponse;
 import com.seam.api.types.LocksLockDoorResponse;
@@ -110,11 +111,11 @@ public class LocksClient {
         return list(LocksListRequest.builder().build());
     }
 
-    public LocksLockDoorResponse lockDoor(LocksLockDoorRequest request) {
+    public ActionAttempt lockDoor(LocksLockDoorRequest request) {
         return lockDoor(request, null);
     }
 
-    public LocksLockDoorResponse lockDoor(LocksLockDoorRequest request, RequestOptions requestOptions) {
+    public ActionAttempt lockDoor(LocksLockDoorRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("locks/lock_door")
@@ -136,7 +137,9 @@ public class LocksClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), LocksLockDoorResponse.class);
+                LocksLockDoorResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), LocksLockDoorResponse.class);
+                return parsedResponse.getActionAttempt();
             }
             throw new ApiError(
                     response.code(),
@@ -146,11 +149,11 @@ public class LocksClient {
         }
     }
 
-    public LocksUnlockDoorResponse unlockDoor(LocksUnlockDoorRequest request) {
+    public ActionAttempt unlockDoor(LocksUnlockDoorRequest request) {
         return unlockDoor(request, null);
     }
 
-    public LocksUnlockDoorResponse unlockDoor(LocksUnlockDoorRequest request, RequestOptions requestOptions) {
+    public ActionAttempt unlockDoor(LocksUnlockDoorRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("locks/unlock_door")
@@ -172,7 +175,9 @@ public class LocksClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), LocksUnlockDoorResponse.class);
+                LocksUnlockDoorResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
+                        response.body().string(), LocksUnlockDoorResponse.class);
+                return parsedResponse.getActionAttempt();
             }
             throw new ApiError(
                     response.code(),

--- a/src/main/java/com/seam/api/resources/noisesensors/noisethresholds/NoiseThresholdsClient.java
+++ b/src/main/java/com/seam/api/resources/noisesensors/noisethresholds/NoiseThresholdsClient.java
@@ -12,12 +12,15 @@ import com.seam.api.resources.noisesensors.noisethresholds.requests.NoiseThresho
 import com.seam.api.resources.noisesensors.noisethresholds.requests.NoiseThresholdsGetRequest;
 import com.seam.api.resources.noisesensors.noisethresholds.requests.NoiseThresholdsListRequest;
 import com.seam.api.resources.noisesensors.noisethresholds.requests.NoiseThresholdsUpdateRequest;
+import com.seam.api.types.ActionAttempt;
+import com.seam.api.types.NoiseThreshold;
 import com.seam.api.types.NoiseThresholdsCreateResponse;
 import com.seam.api.types.NoiseThresholdsDeleteResponse;
 import com.seam.api.types.NoiseThresholdsGetResponse;
 import com.seam.api.types.NoiseThresholdsListResponse;
 import com.seam.api.types.NoiseThresholdsUpdateResponse;
 import java.io.IOException;
+import java.util.List;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -69,11 +72,11 @@ public class NoiseThresholdsClient {
         }
     }
 
-    public NoiseThresholdsDeleteResponse delete(NoiseThresholdsDeleteRequest request) {
+    public ActionAttempt delete(NoiseThresholdsDeleteRequest request) {
         return delete(request, null);
     }
 
-    public NoiseThresholdsDeleteResponse delete(NoiseThresholdsDeleteRequest request, RequestOptions requestOptions) {
+    public ActionAttempt delete(NoiseThresholdsDeleteRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("noise_sensors/noise_thresholds/delete")
@@ -95,8 +98,9 @@ public class NoiseThresholdsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(
-                        response.body().string(), NoiseThresholdsDeleteResponse.class);
+                NoiseThresholdsDeleteResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), NoiseThresholdsDeleteResponse.class);
+                return parsedResponse.getActionAttempt();
             }
             throw new ApiError(
                     response.code(),
@@ -106,11 +110,11 @@ public class NoiseThresholdsClient {
         }
     }
 
-    public NoiseThresholdsGetResponse get(NoiseThresholdsGetRequest request) {
+    public NoiseThreshold get(NoiseThresholdsGetRequest request) {
         return get(request, null);
     }
 
-    public NoiseThresholdsGetResponse get(NoiseThresholdsGetRequest request, RequestOptions requestOptions) {
+    public NoiseThreshold get(NoiseThresholdsGetRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("noise_sensors/noise_thresholds/get")
@@ -132,7 +136,9 @@ public class NoiseThresholdsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), NoiseThresholdsGetResponse.class);
+                NoiseThresholdsGetResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), NoiseThresholdsGetResponse.class);
+                return parsedResponse.getNoiseThreshold();
             }
             throw new ApiError(
                     response.code(),
@@ -142,11 +148,11 @@ public class NoiseThresholdsClient {
         }
     }
 
-    public NoiseThresholdsListResponse list(NoiseThresholdsListRequest request) {
+    public List<NoiseThreshold> list(NoiseThresholdsListRequest request) {
         return list(request, null);
     }
 
-    public NoiseThresholdsListResponse list(NoiseThresholdsListRequest request, RequestOptions requestOptions) {
+    public List<NoiseThreshold> list(NoiseThresholdsListRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("noise_sensors/noise_thresholds/list")
@@ -168,7 +174,9 @@ public class NoiseThresholdsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), NoiseThresholdsListResponse.class);
+                NoiseThresholdsListResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), NoiseThresholdsListResponse.class);
+                return parsedResponse.getNoiseThresholds();
             }
             throw new ApiError(
                     response.code(),
@@ -178,11 +186,11 @@ public class NoiseThresholdsClient {
         }
     }
 
-    public NoiseThresholdsUpdateResponse update(NoiseThresholdsUpdateRequest request) {
+    public ActionAttempt update(NoiseThresholdsUpdateRequest request) {
         return update(request, null);
     }
 
-    public NoiseThresholdsUpdateResponse update(NoiseThresholdsUpdateRequest request, RequestOptions requestOptions) {
+    public ActionAttempt update(NoiseThresholdsUpdateRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("noise_sensors/noise_thresholds/update")
@@ -204,8 +212,9 @@ public class NoiseThresholdsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(
-                        response.body().string(), NoiseThresholdsUpdateResponse.class);
+                NoiseThresholdsUpdateResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), NoiseThresholdsUpdateResponse.class);
+                return parsedResponse.getActionAttempt();
             }
             throw new ApiError(
                     response.code(),

--- a/src/main/java/com/seam/api/resources/thermostats/ThermostatsClient.java
+++ b/src/main/java/com/seam/api/resources/thermostats/ThermostatsClient.java
@@ -13,11 +13,13 @@ import com.seam.api.resources.thermostats.requests.ThermostatsGetRequest;
 import com.seam.api.resources.thermostats.requests.ThermostatsHeatRequest;
 import com.seam.api.resources.thermostats.requests.ThermostatsListRequest;
 import com.seam.api.resources.thermostats.requests.ThermostatsUpdateRequest;
+import com.seam.api.types.Device;
 import com.seam.api.types.ThermostatsGetResponse;
 import com.seam.api.types.ThermostatsHeatResponse;
 import com.seam.api.types.ThermostatsListResponse;
 import com.seam.api.types.ThermostatsUpdateResponse;
 import java.io.IOException;
+import java.util.List;
 import java.util.function.Supplier;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
@@ -36,11 +38,11 @@ public class ThermostatsClient {
         this.climateSettingSchedulesClient = Suppliers.memoize(() -> new ClimateSettingSchedulesClient(clientOptions));
     }
 
-    public ThermostatsGetResponse get(ThermostatsGetRequest request) {
+    public Device get(ThermostatsGetRequest request) {
         return get(request, null);
     }
 
-    public ThermostatsGetResponse get(ThermostatsGetRequest request, RequestOptions requestOptions) {
+    public Device get(ThermostatsGetRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("thermostats/get")
@@ -62,7 +64,9 @@ public class ThermostatsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ThermostatsGetResponse.class);
+                ThermostatsGetResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ThermostatsGetResponse.class);
+                return parsedResponse.getThermostat();
             }
             throw new ApiError(
                     response.code(),
@@ -72,15 +76,15 @@ public class ThermostatsClient {
         }
     }
 
-    public ThermostatsGetResponse get() {
+    public Device get() {
         return get(ThermostatsGetRequest.builder().build());
     }
 
-    public ThermostatsHeatResponse heat(ThermostatsHeatRequest request) {
-        return heat(request, null);
+    public void heat(ThermostatsHeatRequest request) {
+        heat(request, null);
     }
 
-    public ThermostatsHeatResponse heat(ThermostatsHeatRequest request, RequestOptions requestOptions) {
+    public void heat(ThermostatsHeatRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("thermostats/heat")
@@ -102,7 +106,8 @@ public class ThermostatsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ThermostatsHeatResponse.class);
+                ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ThermostatsHeatResponse.class);
+                return;
             }
             throw new ApiError(
                     response.code(),
@@ -112,11 +117,11 @@ public class ThermostatsClient {
         }
     }
 
-    public ThermostatsListResponse list(ThermostatsListRequest request) {
+    public List<Device> list(ThermostatsListRequest request) {
         return list(request, null);
     }
 
-    public ThermostatsListResponse list(ThermostatsListRequest request, RequestOptions requestOptions) {
+    public List<Device> list(ThermostatsListRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("thermostats/list")
@@ -138,7 +143,9 @@ public class ThermostatsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ThermostatsListResponse.class);
+                ThermostatsListResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ThermostatsListResponse.class);
+                return parsedResponse.getThermostats();
             }
             throw new ApiError(
                     response.code(),
@@ -148,15 +155,15 @@ public class ThermostatsClient {
         }
     }
 
-    public ThermostatsListResponse list() {
+    public List<Device> list() {
         return list(ThermostatsListRequest.builder().build());
     }
 
-    public ThermostatsUpdateResponse update(ThermostatsUpdateRequest request) {
-        return update(request, null);
+    public void update(ThermostatsUpdateRequest request) {
+        update(request, null);
     }
 
-    public ThermostatsUpdateResponse update(ThermostatsUpdateRequest request, RequestOptions requestOptions) {
+    public void update(ThermostatsUpdateRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("thermostats/update")
@@ -178,7 +185,8 @@ public class ThermostatsClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ThermostatsUpdateResponse.class);
+                ObjectMappers.JSON_MAPPER.readValue(response.body().string(), ThermostatsUpdateResponse.class);
+                return;
             }
             throw new ApiError(
                     response.code(),

--- a/src/main/java/com/seam/api/resources/workspaces/WorkspacesClient.java
+++ b/src/main/java/com/seam/api/resources/workspaces/WorkspacesClient.java
@@ -7,10 +7,13 @@ import com.seam.api.core.ApiError;
 import com.seam.api.core.ClientOptions;
 import com.seam.api.core.ObjectMappers;
 import com.seam.api.core.RequestOptions;
+import com.seam.api.types.Workspace;
 import com.seam.api.types.WorkspacesGetResponse;
 import com.seam.api.types.WorkspacesListResponse;
 import com.seam.api.types.WorkspacesResetSandboxResponse;
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
@@ -24,11 +27,11 @@ public class WorkspacesClient {
         this.clientOptions = clientOptions;
     }
 
-    public WorkspacesGetResponse get() {
+    public Optional<Workspace> get() {
         return get(null);
     }
 
-    public WorkspacesGetResponse get(RequestOptions requestOptions) {
+    public Optional<Workspace> get(RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("workspaces/get")
@@ -43,7 +46,9 @@ public class WorkspacesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), WorkspacesGetResponse.class);
+                WorkspacesGetResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), WorkspacesGetResponse.class);
+                return parsedResponse.getWorkspace();
             }
             throw new ApiError(
                     response.code(),
@@ -53,11 +58,11 @@ public class WorkspacesClient {
         }
     }
 
-    public WorkspacesListResponse list() {
+    public List<Workspace> list() {
         return list(null);
     }
 
-    public WorkspacesListResponse list(RequestOptions requestOptions) {
+    public List<Workspace> list(RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("workspaces/list")
@@ -72,7 +77,9 @@ public class WorkspacesClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), WorkspacesListResponse.class);
+                WorkspacesListResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), WorkspacesListResponse.class);
+                return parsedResponse.getWorkspaces();
             }
             throw new ApiError(
                     response.code(),

--- a/src/main/java/com/seam/api/types/DeviceListProvider.java
+++ b/src/main/java/com/seam/api/types/DeviceListProvider.java
@@ -15,8 +15,8 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonDeserialize(builder = DevicesListDeviceProvidersResponseDeviceProvidersItem.Builder.class)
-public final class DevicesListDeviceProvidersResponseDeviceProvidersItem {
+@JsonDeserialize(builder = DeviceListProvider.Builder.class)
+public final class DeviceListProvider {
     private final String deviceProviderName;
 
     private final String displayName;
@@ -25,7 +25,7 @@ public final class DevicesListDeviceProvidersResponseDeviceProvidersItem {
 
     private final List<DevicesListDeviceProvidersResponseDeviceProvidersItemProviderCategoriesItem> providerCategories;
 
-    private DevicesListDeviceProvidersResponseDeviceProvidersItem(
+    private DeviceListProvider(
             String deviceProviderName,
             String displayName,
             String imageUrl,
@@ -59,11 +59,11 @@ public final class DevicesListDeviceProvidersResponseDeviceProvidersItem {
     @Override
     public boolean equals(Object other) {
         if (this == other) return true;
-        return other instanceof DevicesListDeviceProvidersResponseDeviceProvidersItem
-                && equalTo((DevicesListDeviceProvidersResponseDeviceProvidersItem) other);
+        return other instanceof DeviceListProvider
+                && equalTo((DeviceListProvider) other);
     }
 
-    private boolean equalTo(DevicesListDeviceProvidersResponseDeviceProvidersItem other) {
+    private boolean equalTo(DeviceListProvider other) {
         return deviceProviderName.equals(other.deviceProviderName)
                 && displayName.equals(other.displayName)
                 && imageUrl.equals(other.imageUrl)
@@ -87,7 +87,7 @@ public final class DevicesListDeviceProvidersResponseDeviceProvidersItem {
     public interface DeviceProviderNameStage {
         DisplayNameStage deviceProviderName(String deviceProviderName);
 
-        Builder from(DevicesListDeviceProvidersResponseDeviceProvidersItem other);
+        Builder from(DeviceListProvider other);
     }
 
     public interface DisplayNameStage {
@@ -99,7 +99,7 @@ public final class DevicesListDeviceProvidersResponseDeviceProvidersItem {
     }
 
     public interface _FinalStage {
-        DevicesListDeviceProvidersResponseDeviceProvidersItem build();
+        DeviceListProvider build();
 
         _FinalStage providerCategories(
                 List<DevicesListDeviceProvidersResponseDeviceProvidersItemProviderCategoriesItem> providerCategories);
@@ -125,7 +125,7 @@ public final class DevicesListDeviceProvidersResponseDeviceProvidersItem {
         private Builder() {}
 
         @Override
-        public Builder from(DevicesListDeviceProvidersResponseDeviceProvidersItem other) {
+        public Builder from(DeviceListProvider other) {
             deviceProviderName(other.getDeviceProviderName());
             displayName(other.getDisplayName());
             imageUrl(other.getImageUrl());
@@ -178,8 +178,8 @@ public final class DevicesListDeviceProvidersResponseDeviceProvidersItem {
         }
 
         @Override
-        public DevicesListDeviceProvidersResponseDeviceProvidersItem build() {
-            return new DevicesListDeviceProvidersResponseDeviceProvidersItem(
+        public DeviceListProvider build() {
+            return new DeviceListProvider(
                     deviceProviderName, displayName, imageUrl, providerCategories);
         }
     }

--- a/src/main/java/com/seam/api/types/DevicesListDeviceProvidersResponse.java
+++ b/src/main/java/com/seam/api/types/DevicesListDeviceProvidersResponse.java
@@ -17,18 +17,18 @@ import java.util.Objects;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonDeserialize(builder = DevicesListDeviceProvidersResponse.Builder.class)
 public final class DevicesListDeviceProvidersResponse {
-    private final List<DevicesListDeviceProvidersResponseDeviceProvidersItem> deviceProviders;
+    private final List<DeviceListProvider> deviceProviders;
 
     private final boolean ok;
 
     private DevicesListDeviceProvidersResponse(
-            List<DevicesListDeviceProvidersResponseDeviceProvidersItem> deviceProviders, boolean ok) {
+            List<DeviceListProvider> deviceProviders, boolean ok) {
         this.deviceProviders = deviceProviders;
         this.ok = ok;
     }
 
     @JsonProperty("device_providers")
-    public List<DevicesListDeviceProvidersResponseDeviceProvidersItem> getDeviceProviders() {
+    public List<DeviceListProvider> getDeviceProviders() {
         return deviceProviders;
     }
 
@@ -71,18 +71,18 @@ public final class DevicesListDeviceProvidersResponse {
     public interface _FinalStage {
         DevicesListDeviceProvidersResponse build();
 
-        _FinalStage deviceProviders(List<DevicesListDeviceProvidersResponseDeviceProvidersItem> deviceProviders);
+        _FinalStage deviceProviders(List<DeviceListProvider> deviceProviders);
 
-        _FinalStage addDeviceProviders(DevicesListDeviceProvidersResponseDeviceProvidersItem deviceProviders);
+        _FinalStage addDeviceProviders(DeviceListProvider deviceProviders);
 
-        _FinalStage addAllDeviceProviders(List<DevicesListDeviceProvidersResponseDeviceProvidersItem> deviceProviders);
+        _FinalStage addAllDeviceProviders(List<DeviceListProvider> deviceProviders);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder implements OkStage, _FinalStage {
         private boolean ok;
 
-        private List<DevicesListDeviceProvidersResponseDeviceProvidersItem> deviceProviders = new ArrayList<>();
+        private List<DeviceListProvider> deviceProviders = new ArrayList<>();
 
         private Builder() {}
 
@@ -102,13 +102,13 @@ public final class DevicesListDeviceProvidersResponse {
 
         @Override
         public _FinalStage addAllDeviceProviders(
-                List<DevicesListDeviceProvidersResponseDeviceProvidersItem> deviceProviders) {
+                List<DeviceListProvider> deviceProviders) {
             this.deviceProviders.addAll(deviceProviders);
             return this;
         }
 
         @Override
-        public _FinalStage addDeviceProviders(DevicesListDeviceProvidersResponseDeviceProvidersItem deviceProviders) {
+        public _FinalStage addDeviceProviders(DeviceListProvider deviceProviders) {
             this.deviceProviders.add(deviceProviders);
             return this;
         }
@@ -116,7 +116,7 @@ public final class DevicesListDeviceProvidersResponse {
         @Override
         @JsonSetter(value = "device_providers", nulls = Nulls.SKIP)
         public _FinalStage deviceProviders(
-                List<DevicesListDeviceProvidersResponseDeviceProvidersItem> deviceProviders) {
+                List<DeviceListProvider> deviceProviders) {
             this.deviceProviders.clear();
             this.deviceProviders.addAll(deviceProviders);
             return this;


### PR DESCRIPTION
The generated SDK now returns resources directly, configured by `x-fern-return`. 