### PR TITLE
:herb: update `ConnectedAccountsGetRequest` union + `LocksClient`

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -16,3 +16,4 @@ src/main/java/com/seam/api/resources/connectedaccounts/ConnectedAccountsClient.j
 src/main/java/com/seam/api/resources/clientsessions/ClientSessionsClient.java
 src/main/java/com/seam/api/resources/actionattempts/ActionAttemptsClient.java
 src/main/java/com/seam/api/resources/accesscodes/AccessCodesClient.java
+src/main/java/com/seam/api/types/ConnectedAccountsGetRequest.java

--- a/src/main/java/com/seam/api/resources/accesscodes/AccessCodesClient.java
+++ b/src/main/java/com/seam/api/resources/accesscodes/AccessCodesClient.java
@@ -234,7 +234,7 @@ public class AccessCodesClient {
             if (response.isSuccessful()) {
                 AccessCodesListResponse parsedResponse = ObjectMappers.JSON_MAPPER.readValue(
                         response.body().string(), AccessCodesListResponse.class);
-                parsedResponse.getAccessCodes();
+                return parsedResponse.getAccessCodes();
             }
             throw new ApiError(
                     response.code(),

--- a/src/main/java/com/seam/api/resources/locks/LocksClient.java
+++ b/src/main/java/com/seam/api/resources/locks/LocksClient.java
@@ -12,11 +12,13 @@ import com.seam.api.resources.locks.requests.LocksListRequest;
 import com.seam.api.resources.locks.requests.LocksLockDoorRequest;
 import com.seam.api.resources.locks.requests.LocksUnlockDoorRequest;
 import com.seam.api.types.ActionAttempt;
+import com.seam.api.types.Device;
 import com.seam.api.types.LocksGetResponse;
 import com.seam.api.types.LocksListResponse;
 import com.seam.api.types.LocksLockDoorResponse;
 import com.seam.api.types.LocksUnlockDoorResponse;
 import java.io.IOException;
+import java.util.List;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -31,11 +33,11 @@ public class LocksClient {
         this.clientOptions = clientOptions;
     }
 
-    public LocksGetResponse get(LocksGetRequest request) {
+    public Device get(LocksGetRequest request) {
         return get(request, null);
     }
 
-    public LocksGetResponse get(LocksGetRequest request, RequestOptions requestOptions) {
+    public Device get(LocksGetRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("locks/get")
@@ -57,7 +59,9 @@ public class LocksClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), LocksGetResponse.class);
+                LocksGetResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), LocksGetResponse.class);
+                return parsedResponse.getDevice();
             }
             throw new ApiError(
                     response.code(),
@@ -67,15 +71,15 @@ public class LocksClient {
         }
     }
 
-    public LocksGetResponse get() {
+    public Device get() {
         return get(LocksGetRequest.builder().build());
     }
 
-    public LocksListResponse list(LocksListRequest request) {
+    public List<Device> list(LocksListRequest request) {
         return list(request, null);
     }
 
-    public LocksListResponse list(LocksListRequest request, RequestOptions requestOptions) {
+    public List<Device> list(LocksListRequest request, RequestOptions requestOptions) {
         HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
                 .newBuilder()
                 .addPathSegments("locks/list")
@@ -97,7 +101,9 @@ public class LocksClient {
             Response response =
                     clientOptions.httpClient().newCall(okhttpRequest).execute();
             if (response.isSuccessful()) {
-                return ObjectMappers.JSON_MAPPER.readValue(response.body().string(), LocksListResponse.class);
+                LocksListResponse parsedResponse =
+                        ObjectMappers.JSON_MAPPER.readValue(response.body().string(), LocksListResponse.class);
+                return parsedResponse.getDevices();
             }
             throw new ApiError(
                     response.code(),
@@ -107,7 +113,7 @@ public class LocksClient {
         }
     }
 
-    public LocksListResponse list() {
+    public List<Device> list() {
         return list(LocksListRequest.builder().build());
     }
 

--- a/src/main/java/com/seam/api/types/ConnectedAccountsGetRequest.java
+++ b/src/main/java/com/seam/api/types/ConnectedAccountsGetRequest.java
@@ -58,12 +58,20 @@ public final class ConnectedAccountsGetRequest {
         return this.value.toString();
     }
 
-    public static ConnectedAccountsGetRequest of(ConnectedAccountsGetRequestConnectedAccountId value) {
-        return new ConnectedAccountsGetRequest(value, 0);
+    public static ConnectedAccountsGetRequest id(String id) {
+        return new ConnectedAccountsGetRequest(
+                ConnectedAccountsGetRequestConnectedAccountId.builder()
+                        .connectedAccountId(id)
+                        .build(),
+                0);
     }
 
-    public static ConnectedAccountsGetRequest of(ConnectedAccountsGetRequestEmail value) {
-        return new ConnectedAccountsGetRequest(value, 1);
+    public static ConnectedAccountsGetRequest email(String email) {
+        return new ConnectedAccountsGetRequest(
+                ConnectedAccountsGetRequestEmail.builder()
+                        .email(email)
+                        .build(),
+                1);
     }
 
     public interface Visitor<T> {
@@ -81,12 +89,17 @@ public final class ConnectedAccountsGetRequest {
         public ConnectedAccountsGetRequest deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
             Object value = p.readValueAs(Object.class);
             try {
-                return of(ObjectMappers.JSON_MAPPER.convertValue(
-                        value, ConnectedAccountsGetRequestConnectedAccountId.class));
+                return new ConnectedAccountsGetRequest(
+                        ObjectMappers.JSON_MAPPER.convertValue(value,
+                                ConnectedAccountsGetRequestConnectedAccountId.class),
+                        0);
             } catch (IllegalArgumentException e) {
             }
             try {
-                return of(ObjectMappers.JSON_MAPPER.convertValue(value, ConnectedAccountsGetRequestEmail.class));
+                return new ConnectedAccountsGetRequest(
+                        ObjectMappers.JSON_MAPPER.convertValue(value,
+                                ConnectedAccountsGetRequestEmail.class),
+                        1);
             } catch (IllegalArgumentException e) {
             }
             throw new JsonParseException(p, "Failed to deserialize");


### PR DESCRIPTION
This PR adds some syntactic sugar to `ConnectedAccountsGetRequest` that makes it easier to fetch accounts based on email or connected account ids. 