### PR TITLE
🌿 Remove Generated Files from `.fernignore`

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -2,22 +2,6 @@
 
 README.md
 
-# return resources directly
-src/main/java/com/seam/api/types/DevicesListDeviceProvidersResponse.java
-src/main/java/com/seam/api/types/DeviceListProvider.java
-src/main/java/com/seam/api/resources/workspaces/WorkspacesClient.java
-src/main/java/com/seam/api/resources/thermostats/ThermostatsClient.java
-src/main/java/com/seam/api/resources/noisesensors/noisethresholds/NoiseThresholdsClient.java
-src/main/java/com/seam/api/resources/locks/LocksClient.java
-src/main/java/com/seam/api/resources/events/EventsClient.java
-src/main/java/com/seam/api/resources/devices/DevicesClient.java
-src/main/java/com/seam/api/resources/connectwebviews/ConnectWebviewsClient.java
-src/main/java/com/seam/api/resources/connectedaccounts/ConnectedAccountsClient.java
-src/main/java/com/seam/api/resources/clientsessions/ClientSessionsClient.java
-src/main/java/com/seam/api/resources/actionattempts/ActionAttemptsClient.java
-src/main/java/com/seam/api/resources/accesscodes/AccessCodesClient.java
-src/main/java/com/seam/api/types/ConnectedAccountsGetRequest.java
-
 # Integration Tests
 src/test/java
 


### PR DESCRIPTION
We longer need to ignore these files thanks to an improvement to the Java generator in version 0.9.6.